### PR TITLE
Add apt install automation to setup

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -148,6 +148,15 @@ case ${OSTYPE} in
 	linux*)
 		# Linux Settings ===============================================================
 
+                # Install packages on apt based systems (such as WSL)
+                if command -v apt >/dev/null 2>&1 ; then
+                        sudo apt update
+                        sudo apt install -y \
+                                ack-grep coreutils exuberant-ctags jq openssl \
+                                libreadline-dev shellcheck silversearcher-ag \
+                                tig tree wget zsh
+                fi
+
 		# tmux config
 		TMUX_LINUX_CONFIG_FILE=".tmux.linux.1.6.conf"
 		if [ -L $HOME/.tmux.conf ] ; then


### PR DESCRIPTION
## Summary
- add apt package installation for Linux environments in `setup.sh`

## Testing
- `apt-get update`
- `apt-get install -y shellcheck`
- `shellcheck setup.sh`

------
https://chatgpt.com/codex/tasks/task_e_68520bec3f3483278125b3a5859fea9e