### PR TITLE
Fix locale warnings on WSL

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,9 @@ cd ~/dotfiles
 bash setup.sh
 ```
 
+The setup script ensures the English UTF-8 locale is available so that commands
+such as `man` do not show locale related warnings.
+
 This will create symbolic links for the configuration files in your home directory.
 When Zsh starts on WSL, `.zshrc` automatically loads `.zshrc.wsl`, which sets useful
 PATH entries and aliases for Windows tools.

--- a/setup.sh
+++ b/setup.sh
@@ -154,7 +154,15 @@ case ${OSTYPE} in
                         sudo apt install -y \
                                 ack-grep coreutils jq openssl \
                                 shellcheck silversearcher-ag \
-                                tig tree wget zsh
+                                tig tree wget zsh locales
+                        # Ensure an English UTF-8 locale exists so that shells
+                        # started after setup do not show locale warnings such
+                        # as:
+                        #   "manpath: can't set the locale; make sure $LC_* and $LANG are correct"
+                        if command -v locale-gen >/dev/null 2>&1 ; then
+                                sudo locale-gen en_US.UTF-8
+                                sudo update-locale LANG=en_US.UTF-8
+                        fi
                 fi
 
 		# tmux config


### PR DESCRIPTION
## Summary
- ensure setup script configures English UTF-8 locale
- document locale generation in README

## Testing
- `bash -n setup.sh`


------
https://chatgpt.com/codex/tasks/task_e_685213b6137083278b0cc17d6c58aeec