### PR TITLE
Add WSL specific Vim config

### DIFF
--- a/.vimrc_wsl
+++ b/.vimrc_wsl
@@ -1,0 +1,13 @@
+scriptencoding utf-8
+set encoding=utf-8
+set showmode
+set scrolloff=10
+set clipboard+=unnamed
+set completeopt-=preview
+set backup
+set backupdir=$HOME/vimbackup
+set foldmethod=syntax
+set foldlevel=20
+nnoremap <C-A> <NOP>
+nnoremap <C-X> <NOP>
+syntax on

--- a/README.md
+++ b/README.md
@@ -20,3 +20,4 @@ such as `man` do not show locale related warnings.
 This will create symbolic links for the configuration files in your home directory.
 When Zsh starts on WSL, `.zshrc` automatically loads `.zshrc.wsl`, which sets useful
 PATH entries and aliases for Windows tools.
+When running `setup.sh` on WSL, `.vimrc` is linked to `.vimrc_wsl` so that Vim uses a minimal configuration that avoids plugin errors.

--- a/setup.sh
+++ b/setup.sh
@@ -22,7 +22,7 @@ rm -f ~/.zshrc
 
 
 # other dotfiles
-DOT_FILES=( .tigrc .ctags .gemrc .gitignore_global .gvimrc .irbrc .perlcriticrc .perltidyrc .profile .rubocop.yml .vimrc .ideavimrc .zshrc .zshrc.alias .zshrc.custom .zshrc.linux .zshrc.osx .zshrc.wsl .atcodertools.toml )
+DOT_FILES=( .tigrc .ctags .gemrc .gitignore_global .gvimrc .irbrc .perlcriticrc .perltidyrc .profile .rubocop.yml .ideavimrc .zshrc .zshrc.alias .zshrc.custom .zshrc.linux .zshrc.osx .zshrc.wsl .vimrc_wsl .atcodertools.toml )
 
 for file in ${DOT_FILES[@]}
 do
@@ -34,6 +34,18 @@ do
 	fi
 done
 
+# Handle Vim configuration
+if grep -qi microsoft /proc/version 2>/dev/null ; then
+    VIMRC_TARGET=".vimrc_wsl"
+else
+    VIMRC_TARGET=".vimrc"
+fi
+if [ -L "$HOME/.vimrc" ] ; then
+    printf "%-30s already exists.\n" ".vimrc"
+else
+    ln -s "$HOME/dotfiles/$VIMRC_TARGET" "$HOME/.vimrc"
+    printf "Made symbolic link $HOME/.vimrc\n"
+fi
 
 # copy some dotfiles
 DOT_FILES_TO_COPY=( .gitconfig )


### PR DESCRIPTION
## Summary
- add `.vimrc_wsl` for a simple Vim setup under WSL
- link `.vimrc` to `.vimrc_wsl` when running `setup.sh` on WSL
- document the behaviour in README

## Testing
- `bash -n setup.sh`

------
https://chatgpt.com/codex/tasks/task_e_6852197b040883278cd93936ab2e2f73