### PR TITLE
Alias vi/vim to nvim

### DIFF
--- a/.zshrc.alias
+++ b/.zshrc.alias
@@ -6,4 +6,5 @@
 #
 alias mv="mv -v"
 alias tree="tree -C"
-alias vi='vim'
+alias vi='nvim'
+alias vim='nvim'

--- a/.zshrc.custom
+++ b/.zshrc.custom
@@ -8,7 +8,7 @@ colors
 
 bindkey -v
 
-export EDITOR=vim
+export EDITOR=nvim
 export LANG=ja_JP.UTF-8
 export KCODE=u
 export LESSCHARSET=utf-8

--- a/.zshrc.osx
+++ b/.zshrc.osx
@@ -23,9 +23,9 @@ export PATH=/usr/local/bin:/usr/local/sbin:$PATH
 eval "$(/opt/homebrew/bin/brew shellenv)"
 
 # Vim
-export EDITOR=/Applications/MacVim.app/Contents/MacOS/Vim
-# alias vim='env LANG=ja_JP.UTF-8 /Applications/MacVim.app/Contents/MacOS/Vim "$@"'
-alias vim='env LANG=en_US.UTF-8 /Applications/MacVim.app/Contents/MacOS/Vim "$@"'
+export EDITOR=nvim
+alias vi='nvim'
+alias vim='nvim'
 
 # asdf
 . /opt/homebrew/opt/asdf/libexec/asdf.sh


### PR DESCRIPTION
## Summary
- alias `vi` and `vim` to `nvim`
- update default editor to `nvim` for macOS and custom zsh configs

## Testing
- `grep --color=never -n "alias vi" -R`


------
https://chatgpt.com/codex/tasks/task_e_685225016ef88327993402f076204cc3