### PR TITLE
Fix locale warning on zsh start

### DIFF
--- a/.zshrc.custom
+++ b/.zshrc.custom
@@ -9,7 +9,7 @@ colors
 bindkey -v
 
 export EDITOR=nvim
-export LANG=ja_JP.UTF-8
+export LANG=C.UTF-8
 export KCODE=u
 export LESSCHARSET=utf-8
 


### PR DESCRIPTION
## Summary
- configure `.zshrc.custom` to use `C.UTF-8` which is installed in this environment

## Testing
- `shellcheck .zshrc.custom`

------
https://chatgpt.com/codex/tasks/task_e_685226e786ac8327a706a2af39f82f14