### PR TITLE
Switch Neovim setup to Lua

### DIFF
--- a/.vimrc
+++ b/.vimrc
@@ -1,3 +1,10 @@
+
+" Use Lua-based configuration when running under Neovim
+if has('nvim')
+  luafile ~/.config/nvim/init.lua
+  finish
+endif
+
 set nocompatible
 set number
 syntax on

--- a/README.md
+++ b/README.md
@@ -20,3 +20,11 @@ such as `man` do not show locale related warnings.
 This will create symbolic links for the configuration files in your home directory.
 When Zsh starts on WSL, `.zshrc` automatically loads `.zshrc.wsl`, which sets useful
 PATH entries and aliases for Windows tools.
+
+## Neovim configuration
+
+This repository provides a Lua-based configuration for Neovim under the
+`nvim` directory. Running `setup.sh` creates a symbolic link at
+`~/.config/nvim` pointing to this folder so that Neovim automatically loads
+`init.lua`. When Neovim starts via the provided `.vimrc`, it forwards to this
+Lua configuration.

--- a/nvim/init.lua
+++ b/nvim/init.lua
@@ -1,4 +1,4 @@
--- Minimal Neovim configuration
+-- Minimal Neovim configuration in Lua
 vim.opt.number = true
 vim.cmd('syntax on')
 vim.cmd('filetype plugin indent on')


### PR DESCRIPTION
## Summary
- add a short note in the README about Lua-based Neovim config
- forward Neovim startup in `.vimrc` to `nvim/init.lua`
- clarify comment in `nvim/init.lua`

## Testing
- `nvim --headless +q` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852271c79b88327b3bc844ae17c747a