### PR TITLE
Add build-essential to apt packages

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -139,7 +139,7 @@ case ${OSTYPE} in
                         sudo apt install -y \
                                 ack-grep coreutils jq openssl \
                                 shellcheck silversearcher-ag neovim \
-                                tig tree wget zsh locales
+                                tig tree wget zsh locales build-essential
                 fi
 
 		# tmux config


### PR DESCRIPTION
## Summary
- add build-essential to the apt install list in `setup.sh`

## Testing
- `shellcheck setup.sh` *(fails: SC1009, SC1073, SC1072)*

------
https://chatgpt.com/codex/tasks/task_e_68522a5a813483279fe5ca61ff56e675