### PR TITLE
Fix ESC+j/k line shifting in tmux

### DIFF
--- a/.tmux.basic.conf
+++ b/.tmux.basic.conf
@@ -1,4 +1,5 @@
 set -g prefix C-a
+set -s escape-time 0
 
 # Command Sequence for Nested Tmux Sessions
 # bind-key C-a send-prefix

--- a/.tmux.linux.1.6.conf
+++ b/.tmux.linux.1.6.conf
@@ -3,6 +3,7 @@
 # version 1.6
 
 set -g prefix C-a
+set -s escape-time 0
 
 # Command Sequence for Nested Tmux Sessions
 # bind-key C-a send-prefix

--- a/.tmux.linux.1.9.conf
+++ b/.tmux.linux.1.9.conf
@@ -3,6 +3,7 @@
 # version 1.9 or later
 
 set -g prefix C-a
+set -s escape-time 0
 
 # Command Sequence for Nested Tmux Sessions
 # bind-key C-a send-prefix

--- a/.tmux.osx.1.9.conf
+++ b/.tmux.osx.1.9.conf
@@ -3,6 +3,7 @@
 # version 1.9 or later
 
 set -g prefix C-a
+set -s escape-time 0
 
 # Command Sequence for Nested Tmux Sessions
 # bind-key C-a send-prefix


### PR DESCRIPTION
## Summary
- disable tmux's Meta key timeout by setting `escape-time 0`
- update all tmux configuration variants

## Testing
- `nvim --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68522d2f4d148327aab1f50be83fb0da