### PR TITLE
Install Neovim via AppImage on WSL

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ such as `man` do not show locale related warnings.
 This will create symbolic links for the configuration files in your home directory.
 When Zsh starts on WSL, `.zshrc` automatically loads `.zshrc.wsl`, which sets useful
 PATH entries and aliases for Windows tools.
+The script also downloads the latest Neovim AppImage to `~/bin/nvim` so you can use a modern version regardless of the packages provided by your distribution.
 
 ## Neovim configuration
 

--- a/setup.sh
+++ b/setup.sh
@@ -138,8 +138,18 @@ case ${OSTYPE} in
                         sudo apt update
                         sudo apt install -y \
                                 ack-grep coreutils jq openssl \
-                                shellcheck silversearcher-ag neovim \
+                                shellcheck silversearcher-ag curl \
                                 tig tree wget zsh locales build-essential
+                fi
+
+                # Install the latest Neovim AppImage
+                NVIM_APPIMAGE="$HOME/bin/nvim"
+                if [ ! -f "$NVIM_APPIMAGE" ] ; then
+                        curl -L https://github.com/neovim/neovim/releases/latest/download/nvim.appimage -o "$NVIM_APPIMAGE"
+                        chmod u+x "$NVIM_APPIMAGE"
+                        printf "Installed latest Neovim to $NVIM_APPIMAGE\n"
+                else
+                        printf "%-30s already exists.\n" "$NVIM_APPIMAGE"
                 fi
 
 		# tmux config


### PR DESCRIPTION
## Summary
- install Neovim from the official AppImage in `setup.sh`
- mention the AppImage install in the WSL instructions

## Testing
- `bash -n setup.sh`

------
https://chatgpt.com/codex/tasks/task_e_685249d7add48327b86de1c0b4502f06