### PR TITLE
Fix nvim appimage download

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ such as `man` do not show locale related warnings.
 This will create symbolic links for the configuration files in your home directory.
 When Zsh starts on WSL, `.zshrc` automatically loads `.zshrc.wsl`, which sets useful
 PATH entries and aliases for Windows tools.
-The script also downloads the latest Neovim AppImage to `~/bin/nvim` so you can use a modern version regardless of the packages provided by your distribution.
+The script also downloads the latest Neovim AppImage to `~/bin/nvim` so you can use a modern version regardless of the packages provided by your distribution. If the download fails due to network restrictions, remove the partially downloaded file and install Neovim manually.
 
 ## Neovim configuration
 

--- a/setup.sh
+++ b/setup.sh
@@ -145,9 +145,13 @@ case ${OSTYPE} in
                 # Install the latest Neovim AppImage
                 NVIM_APPIMAGE="$HOME/bin/nvim"
                 if [ ! -f "$NVIM_APPIMAGE" ] ; then
-                        curl -L https://github.com/neovim/neovim/releases/latest/download/nvim.appimage -o "$NVIM_APPIMAGE"
-                        chmod u+x "$NVIM_APPIMAGE"
-                        printf "Installed latest Neovim to $NVIM_APPIMAGE\n"
+                        if curl -L --fail https://github.com/neovim/neovim/releases/latest/download/nvim.appimage -o "$NVIM_APPIMAGE" ; then
+                                chmod u+x "$NVIM_APPIMAGE"
+                                printf "Installed latest Neovim to $NVIM_APPIMAGE\n"
+                        else
+                                printf "Failed to download Neovim AppImage\n" >&2
+                                rm -f "$NVIM_APPIMAGE"
+                        fi
                 else
                         printf "%-30s already exists.\n" "$NVIM_APPIMAGE"
                 fi


### PR DESCRIPTION
## Summary
- fix `setup.sh` to check curl success when fetching the Neovim AppImage
- document manual install fallback if the download fails

## Testing
- `bash -n setup.sh`
- `shellcheck setup.sh` *(fails: SC1073, SC1072, SC1009)*

------
https://chatgpt.com/codex/tasks/task_e_68524bc9b9348327a937e6196662f724