### PR TITLE
Add cdwin alias

### DIFF
--- a/.zshrc.wsl
+++ b/.zshrc.wsl
@@ -5,6 +5,7 @@ export PATH="$PATH:/mnt/c/Windows/System32"
 # Convenience aliases for accessing Windows tools
 alias explorer='/mnt/c/Windows/explorer.exe'
 alias clip='clip.exe'
+alias cdwin='cd /mnt/c/Users/teles'
 
 # Default display when using an X server
 export DISPLAY=:0


### PR DESCRIPTION
## Summary
- add `cdwin` alias to `.zshrc.wsl` for quick access to Windows home

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6852737a1b6c8327aa8438a990411bf3